### PR TITLE
flibusta url changed to current working

### DIFF
--- a/flibusta.py
+++ b/flibusta.py
@@ -12,12 +12,12 @@ from calibre.gui2.store.search_result import SearchResult
 
 class FlibustaStore(BasicStoreConfig, OpenSearchOPDSStore):
 
-    open_search_url = 'http://flibusta.net/opds-opensearch.xml'
-    web_url = 'http://flibusta.net/'
+    open_search_url = 'http://flibusta.is/opds-opensearch.xml'
+    web_url = 'http://flibusta.is/'
 
     def search(self, query, max_results=10, timeout=60):
         for s in OpenSearchOPDSStore.search(self, query, max_results, timeout):
-            s.detail_item = 'http://flibusta.net/b/' + s.detail_item.split(':')[-1]
+            s.detail_item = 'http://flibusta.is/b/' + s.detail_item.split(':')[-1]
             s.price = '$0.00'
             s.drm = SearchResult.DRM_UNLOCKED
             yield s


### PR DESCRIPTION
Your version of plugin is not working because flibusta url has been changed.
I fix it to current 'working URL flibusta.is'
All work fine
Thanks for the plugin!
